### PR TITLE
Add support for the client_scheme_in_redirect directive

### DIFF
--- a/contrib/vim/syntax/nginx.vim
+++ b/contrib/vim/syntax/nginx.vim
@@ -96,6 +96,7 @@ syn keyword ngxDirective client_body_timeout
 syn keyword ngxDirective client_header_buffer_size
 syn keyword ngxDirective client_header_timeout
 syn keyword ngxDirective client_max_body_size
+syn keyword ngxDirective client_scheme_in_redirect
 syn keyword ngxDirective connection_pool_size
 syn keyword ngxDirective create_full_put_path
 syn keyword ngxDirective daemon

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -402,6 +402,7 @@ struct ngx_http_core_loc_conf_s {
     ngx_flag_t    tcp_nopush;              /* tcp_nopush */
     ngx_flag_t    tcp_nodelay;             /* tcp_nodelay */
     ngx_flag_t    reset_timedout_connection; /* reset_timedout_connection */
+    ngx_http_complex_value_t    *client_scheme_in_redirect; /* client_scheme_in_redirect */
     ngx_flag_t    server_name_in_redirect; /* server_name_in_redirect */
     ngx_flag_t    port_in_redirect;        /* port_in_redirect */
     ngx_flag_t    msie_padding;            /* msie_padding */


### PR DESCRIPTION
Syntax:	**client_scheme_in_redirect** _scheme_;
Default:	—
Context:	http, server, location

---
Defines the scheme in redirects issued by nginx. When not specified, the scheme will be `https` if the current connection is over ssl and `http` otherwise. See [$scheme](http://nginx.org/en/docs/http/ngx_http_core_module.html#var_scheme).   The _scheme_ value can contain variables.

Example:
```
error_log logs/error.log;

events {
  worker_connections  1024;
}

http {

    map $http_user_agent_https $client_scheme {
        default $scheme;
        ON https;
        OFF http;
    }

    index    index.html index.htm index.php;
    server {
        listen 8080;
        root /www/nginx_root;

        location / {
            client_scheme_in_redirect $client_scheme;
        }
    }
}
```
The use of the primary server name in redirects is controlled by the [server_name_in_redirect](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_name_in_redirect) directive.
The use of a port in redirects is controlled by the [port_in_redirect](http://nginx.org/en/docs/http/ngx_http_core_module.html#port_in_redirect) directive.
